### PR TITLE
API for posts creation

### DIFF
--- a/blog/api/serializers.py
+++ b/blog/api/serializers.py
@@ -3,6 +3,9 @@ from blog.models import Post
 
 
 class PostSerializer(serializers.ModelSerializer):
+
+    #user string related fields
+    author = serializers.StringRelatedField()
     class Meta:
         model = Post
         fields = ['title','body','author']

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -119,7 +119,9 @@ class PostAPITest(APITestCase):
         Post.objects.create(title="test", body="test", author=User.objects.get(username="testuser"))
         self.user = User.objects.get(username="testuser")
 
-    def test_post_get_api(self):
+    def test_post_list(self):
+        #Force authentication
+        self.client.force_authenticate(user=self.user)
         #Getting the response from the API
         response = self.client.get(reverse('blog:post_list'))
 
@@ -144,3 +146,22 @@ class PostAPITest(APITestCase):
         #Checking if the response is the same as the database
         count = Post.objects.count()
         self.assertEqual(count, len(response.data))
+
+    def test_post_create(self):
+        #Force authentication
+        self.client.force_authenticate(user=self.user)
+
+        #Getting the response from the API
+        response = self.client.post(reverse('blog:post_list'),{
+            'title': 'testing',
+            'body': 'testing'
+        })
+
+        #Checking if response is OK
+        self.assertEqual(response.status_code, 201)
+
+        #Checking if the response is the same as the database
+        post = Post.objects.get(pk=2)
+        self.assertEqual(post.title, response.data['title'])
+        self.assertEqual(post.body, response.data['body'])
+        self.assertEqual(post.author.username, response.data['author'])

--- a/blog/views.py
+++ b/blog/views.py
@@ -1,4 +1,5 @@
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.mixins import CreateModelMixin
 from rest_framework.generics import GenericAPIView
 from rest_framework.mixins import ListModelMixin
 from django.contrib.auth.views import LoginView
@@ -9,7 +10,6 @@ from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.shortcuts import render
 from django.contrib import messages
-from rest_framework import status
 from .forms import SignUpForm
 from .models import Post
 
@@ -33,8 +33,8 @@ class MyLoginView(LoginView):
         context['actionText'] = 'Log In'
         return context
 
-#inherit from GenericAPIView and ListLodelMixin
-class PostViewSet(GenericAPIView, ListModelMixin):
+
+class PostViewSet(GenericAPIView, ListModelMixin, CreateModelMixin):
     queryset = Post.objects.all()
     serializer_class = PostSerializer
     permission_classes = [IsAuthenticated]
@@ -43,10 +43,7 @@ class PostViewSet(GenericAPIView, ListModelMixin):
         return self.list(request, *args, **kwargs)
     
     def post(self, request, *args, **kwargs):
-        serializer = self.get_serializer(data=request.data)
-        serializer.is_valid(raise_exception=True)
-        serializer.save(author=request.user)
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return self.create(request, *args, **kwargs)
                            
     def perform_create(self, serializer):
         serializer.save(author=self.request.user)

--- a/blog/views.py
+++ b/blog/views.py
@@ -1,12 +1,15 @@
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.generics import GenericAPIView
 from rest_framework.mixins import ListModelMixin
 from django.contrib.auth.views import LoginView
 from blog.api.serializers import PostSerializer
+from rest_framework.response import Response
 from django.contrib.auth import logout
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.shortcuts import render
 from django.contrib import messages
+from rest_framework import status
 from .forms import SignUpForm
 from .models import Post
 
@@ -34,9 +37,19 @@ class MyLoginView(LoginView):
 class PostViewSet(GenericAPIView, ListModelMixin):
     queryset = Post.objects.all()
     serializer_class = PostSerializer
+    permission_classes = [IsAuthenticated]
 
     def get(self, request, *args, **kwargs):
         return self.list(request, *args, **kwargs)
+    
+    def post(self, request, *args, **kwargs):
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save(author=request.user)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+                           
+    def perform_create(self, serializer):
+        serializer.save(author=self.request.user)
 
 def signUp(request):
     if request.method == 'POST':

--- a/myblog/settings.py
+++ b/myblog/settings.py
@@ -136,3 +136,12 @@ STATIC_URL = 'static/'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 LOGIN_REDIRECT_URL = 'blog:index'
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.BasicAuthentication',
+    ],
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated',
+    ],
+}


### PR DESCRIPTION
Changes made:
- In post serializer user field set to string representation
- API configured to require authentication 
- POST method implemented for post creation on /blog/api/post
- Test created for post creation (POST method)
- Test for post list edited and renamed to test_post_list (GET method)